### PR TITLE
Update OAuthController.php

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -105,7 +105,7 @@ class OAuthController extends Controller
         if (! is_null($user = Auth::user())) {
             if ($account && $account->user_id !== $user->id) {
                 return redirect()->route('profile.show')->dangerBanner([
-                    $provider.'_connect_error' => __('This :Provider sign in account is already associated with another user. Please try a different account.', ['provider' => $provider]),
+                    __('This :Provider sign in account is already associated with another user. Please try a different account.', ['provider' => $provider]),
                 ]);
             }
 
@@ -118,7 +118,7 @@ class OAuthController extends Controller
             }
 
             return redirect()->route('profile.show')->dangerBanner([
-                $provider.'_connect_error' => __('This :Provider sign in account is already associated with your user.', ['provider' => $provider]),
+                __('This :Provider sign in account is already associated with your user.', ['provider' => $provider]),
             ]);
         }
 


### PR DESCRIPTION
dangerBanner breaks due to the $provider_error key. Banner displays [object, object].

Recreate this issue by connecting an account to an already existing social account. 

**This :Provider sign in account is already associated with another user. Please try a different account.**